### PR TITLE
Move transactions into the blocks table for performance, Py3 and PEP8 compliance, and configuration classes for different environments

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,5 +2,6 @@ class FlaskConfig(object):
   DEBUG = True
   TESTING = True
   TEMPLATE_DEBUG = True
+  TEMPLATES_AUTO_RELOAD = True
   WTF_CSRF_ENABLED = False
   SECRET_KEY = 'lQT0EE/XcyZrXDjCCJ/KRs3F2zKc0Ls3KAmT4y0pxp4='

--- a/config.py
+++ b/config.py
@@ -1,7 +1,31 @@
-class FlaskConfig(object):
-  DEBUG = True
-  TESTING = True
-  TEMPLATE_DEBUG = True
-  TEMPLATES_AUTO_RELOAD = True
-  WTF_CSRF_ENABLED = False
-  SECRET_KEY = 'lQT0EE/XcyZrXDjCCJ/KRs3F2zKc0Ls3KAmT4y0pxp4='
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+"""
+This is a configuration file for the Zcash block observatory.
+"""
+
+class ShowBlocksConfig(object):
+    BLOCK_OBSERVATORY_URL = 'http://127.0.0.1:8200/'
+    BIND_PORT = 8201
+    DB_FILE = 'blocks.sqlite'
+    DEBUG = True
+    TESTING = True
+    TEMPLATE_DEBUG = True
+    TEMPLATES_AUTO_RELOAD = True
+    SECRET_KEY = 'lQT0EE/XcyZrXDjCCJ/KRs3F2zKc0Ls3KAmT4y0pxp4='
+
+class ReceiveBlocksConfig(object):
+    DB_FILE = 'blocks.sqlite'
+    BIND_PORT = 8200
+    DEBUG = True
+    TESTING = True
+
+class SendBlocksConfig(dict):
+    BLOCK_OBSERVATORY_URL = 'http://127.0.0.1:8200/'
+    ZCASH_CLI_PATH = '/usr/bin/zcash-cli'
+
+class LoadBlocksConfig(dict):
+    BLOCK_OBSERVATORY_URL = 'http://127.0.0.1:8200/'
+    ZCASH_CLI_PATH = '/usr/bin/zcash-cli'
+    STARTING_BLOCK_HEIGHT = 0
+    ENDING_BLOCK_HEIGHT = 108353

--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 class FlaskConfig(object):
-  DEBUG = False
-  TESTING = False
+  DEBUG = True
+  TESTING = True
+  TEMPLATE_DEBUG = True
   WTF_CSRF_ENABLED = False
   SECRET_KEY = 'lQT0EE/XcyZrXDjCCJ/KRs3F2zKc0Ls3KAmT4y0pxp4='

--- a/config.py
+++ b/config.py
@@ -15,8 +15,8 @@ class ShowBlocksConfig(object):
     SECRET_KEY = 'lQT0EE/XcyZrXDjCCJ/KRs3F2zKc0Ls3KAmT4y0pxp4='
 
 class ReceiveBlocksConfig(object):
-    DB_FILE = 'blocks.sqlite'
     BIND_PORT = 8200
+    DB_FILE = 'blocks.sqlite'
     DEBUG = True
     TESTING = True
 
@@ -27,5 +27,5 @@ class SendBlocksConfig(dict):
 class LoadBlocksConfig(dict):
     BLOCK_OBSERVATORY_URL = 'http://127.0.0.1:8200/'
     ZCASH_CLI_PATH = '/usr/bin/zcash-cli'
-    STARTING_BLOCK_HEIGHT = 0
-    ENDING_BLOCK_HEIGHT = 108353
+    START_BLOCK_HEIGHT = 0
+    END_BLOCK_HEIGHT = 108560

--- a/loadblocks.py
+++ b/loadblocks.py
@@ -4,8 +4,8 @@
 import json
 import subprocess
 import requests
-from config import LoadBlocksConfig
 
+from config import LoadBlocksConfig
 config = LoadBlocksConfig
 
 def zcash(cmd):

--- a/loadblocks.py
+++ b/loadblocks.py
@@ -1,12 +1,28 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+import argparse
 import json
+import os
 import subprocess
 import requests
 
 from config import LoadBlocksConfig
 config = LoadBlocksConfig
+
+def parse_cmd_args():
+    description = """
+Allows one to specify the block range to import via STARTING_BLOCK_HEIGHT and ENDING_BLOCK_HEIGHT
+Examples:
+     export STARTING_BLOCK_HEIGHT=1234
+     export ENDING_BLOCK_HEIGHT=12345678
+     ./loadblocks.py
+"""
+    parser = argparse.ArgumentParser(description=description,
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('--start', type=int, default=os.environ.get('STARTING_BLOCK_HEIGHT', 0), required=False, help="Block number to begin import from")
+    parser.add_argument('--end', type=int, default=os.environ.get('ENDING_BLOCK_HEIGHT', None), required=False, help="Block number to stop importing at")
+    return parser.parse_args()
 
 def zcash(cmd):
     zcash = subprocess.Popen([config.ZCASH_CLI_PATH, cmd], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -31,14 +47,19 @@ def get_block(block_height):
     return json.loads(output)
 
 def main():
+    args = parse_cmd_args()
+    is_zcashd_running()
+    if not (args.start or args.end):
+        start_point = config.STARTING_BLOCK_HEIGHT
+        end_point = config.ENDING_BLOCK_HEIGHT
     number_of_blocks = zcash('getinfo')['blocks'] if zcash('getinfo') is not False else None
     if number_of_blocks is not None:
         session = requests.session()
         session.headers.update({'Content-Type': 'application/json'})
-        for x in range(config.STARTING_BLOCK_HEIGHT if (config.STARTING_BLOCK_HEIGHT > 0) \
-            else config.STARTING_BLOCK_HEIGHT, config.ENDING_BLOCK_HEIGHT \
-            if (config.ENDING_BLOCK_HEIGHT < number_of_blocks) \
-            else config.ENDING_BLOCK_HEIGHT):
+        for x in range(start_point if (start_point > 0) \
+            else start_point, end_point \
+            if (end_point < number_of_blocks) \
+            else end_point):
                 block = get_block(str(x))
                 r = session.post(config.BLOCK_OBSERVATORY_URL, json=block)
                 r.raise_for_status()

--- a/loadblocks.py
+++ b/loadblocks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import json, os, requests, subprocess, sys, time
+import json, requests, subprocess
 block_observatory_url = 'http://127.0.0.1:8200/'
 
 def zcash(cmd):

--- a/loadblocks.py
+++ b/loadblocks.py
@@ -1,27 +1,52 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import json, requests, subprocess
-block_observatory_url = 'http://127.0.0.1:8200/'
+import json
+import subprocess
+import requests
+from config import LoadBlocksConfig
+
+config = LoadBlocksConfig
 
 def zcash(cmd):
-    zcash = subprocess.Popen(['/usr/bin/zcash-cli', cmd], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    zcash = subprocess.Popen([config.ZCASH_CLI_PATH, cmd], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
     output = zcash.communicate()[0]
+    try:
+        json.loads(output)
+    except Exception as e:
+        print(e)
+        print('Error: Can\'t communicate with Zcash RPC Interface.')
+        return False
     return json.loads(output)
 
 def get_block(block_height):
-    zcash = subprocess.Popen(['/usr/bin/zcash-cli', 'getblock', block_height], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    zcash = subprocess.Popen([config.ZCASH_CLI_PATH, 'getblock', block_height], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
     output = zcash.communicate()[0]
+    try:
+        json.loads(output)
+    except Exception as e:
+        print(e)
+        print('Error: Can\'t retrieve block number ' + block_height + ' from zcashd.')
+        return False
     return json.loads(output)
 
 def main():
-    number_of_blocks = zcash('getinfo')['blocks']
-    session = requests.session()
-    session.headers.update({'Content-Type': 'application/json'})
-    for x in range (0, number_of_blocks):
-        block = get_block(str(x))
-        r = session.post(block_observatory_url, json=block)
-        r.raise_for_status()
+    number_of_blocks = zcash('getinfo')['blocks'] if zcash('getinfo') is not False else None
+    if number_of_blocks is not None:
+        session = requests.session()
+        session.headers.update({'Content-Type': 'application/json'})
+        for x in range(config.STARTING_BLOCK_HEIGHT if (config.STARTING_BLOCK_HEIGHT > 0) \
+            else config.STARTING_BLOCK_HEIGHT, config.ENDING_BLOCK_HEIGHT \
+            if (config.ENDING_BLOCK_HEIGHT < number_of_blocks) \
+            else config.ENDING_BLOCK_HEIGHT):
+                block = get_block(str(x))
+                r = session.post(config.BLOCK_OBSERVATORY_URL, json=block)
+                r.raise_for_status()
+                print('Uploaded block ' + str(x) + '.')
+    else:
+        print('Error: Can\'t retrieve blocks from zcashd.')
+        exit(1)
+    exit(0)
 
 if __name__ == '__main__':
     main()

--- a/loadblocks.py
+++ b/loadblocks.py
@@ -3,8 +3,11 @@
 
 import argparse
 import json
+import getpass
 import os
+import psutil
 import subprocess
+import sys
 import requests
 
 from config import LoadBlocksConfig
@@ -12,21 +15,47 @@ config = LoadBlocksConfig
 
 def parse_cmd_args():
     description = """
-Allows one to specify the block range to import via STARTING_BLOCK_HEIGHT and ENDING_BLOCK_HEIGHT
-Examples:
-     export STARTING_BLOCK_HEIGHT=1234
-     export ENDING_BLOCK_HEIGHT=12345678
+Allows one to specify the block range to import via START_BLOCK_HEIGHT and END_BLOCK_HEIGHT
+Example:
+     export START_BLOCK_HEIGHT=1234
+     export END_BLOCK_HEIGHT=12345678
      ./loadblocks.py
+or...
+     ./loadblocks.py --start 1234 --end 12345678
 """
     parser = argparse.ArgumentParser(description=description,
                                      formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('--start', type=int, default=os.environ.get('STARTING_BLOCK_HEIGHT', 0), required=False, help="Block number to begin import from")
-    parser.add_argument('--end', type=int, default=os.environ.get('ENDING_BLOCK_HEIGHT', None), required=False, help="Block number to stop importing at")
+    parser.add_argument('--start', type=int, default=os.environ.get('START_BLOCK_HEIGHT', 0), required=False, help="Block number to begin import from")
+    parser.add_argument('--end', type=int, default=os.environ.get('END_BLOCK_HEIGHT', zcash('getblockcount')), required=False, help="Block number to stop importing at")
     return parser.parse_args()
 
+def zcashd_access_test(proc):
+    current_user = str(getpass.getuser())
+    try:
+        os.kill(proc['pid'], 0)
+        if proc['username'] == current_user:
+            print('Success: found zcashd is running as ' + current_user + ' allowing RPC interface access.')
+            return True
+    except Exception as e:
+        print(e)
+        print('Error: This zcashd does not seem to be running as the user of this script.')
+        return False
+
+def is_zcashd_running():
+    zcashd_procs = filter(lambda p: p.name() == "zcashd", psutil.process_iter())
+    if zcashd_procs is not [] and len(zcashd_procs) >= 1:
+        procs = [proc.as_dict(attrs=['pid', 'username']) for proc in zcashd_procs]
+        for proc in procs:
+            print("zcashd running with pid %d as user %s" % (proc['pid'], proc['username']))
+            while zcashd_access_test(proc):
+                return True
+    else:
+        print('Error: Could not find an accessible running iinstance of zcashd on this system.')
+        return False
+
 def zcash(cmd):
-    zcash = subprocess.Popen([config.ZCASH_CLI_PATH, cmd], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-    output = zcash.communicate()[0]
+    zcexec = subprocess.Popen([config.ZCASH_CLI_PATH, cmd], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    output = zcexec.communicate()[0]
     try:
         json.loads(output)
     except Exception as e:
@@ -36,8 +65,8 @@ def zcash(cmd):
     return json.loads(output)
 
 def get_block(block_height):
-    zcash = subprocess.Popen([config.ZCASH_CLI_PATH, 'getblock', block_height], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-    output = zcash.communicate()[0]
+    zcexec = subprocess.Popen([config.ZCASH_CLI_PATH, 'getblock', block_height], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    output = zcexec.communicate()[0]
     try:
         json.loads(output)
     except Exception as e:
@@ -47,27 +76,32 @@ def get_block(block_height):
     return json.loads(output)
 
 def main():
+    if not is_zcashd_running():
+        sys.exit(1)
+
     args = parse_cmd_args()
-    is_zcashd_running()
-    if not (args.start or args.end):
-        start_point = config.STARTING_BLOCK_HEIGHT
-        end_point = config.ENDING_BLOCK_HEIGHT
-    number_of_blocks = zcash('getinfo')['blocks'] if zcash('getinfo') is not False else None
-    if number_of_blocks is not None:
+
+    if (args.start and args.end):
+        start_point = args.start
+        end_point = args.end
+    else:
+        start_point = config.START_BLOCK_HEIGHT
+        end_point = config.END_BLOCK_HEIGHT
+
+    num_blocks = zcash('getinfo')['blocks'] if zcash('getinfo') is not False else None
+    if num_blocks is not None:
         session = requests.session()
         session.headers.update({'Content-Type': 'application/json'})
-        for x in range(start_point if (start_point > 0) \
-            else start_point, end_point \
-            if (end_point < number_of_blocks) \
-            else end_point):
+        for x in range(start_point if (start_point > 0) else start_point,
+            end_point if (end_point < num_blocks) else end_point):
                 block = get_block(str(x))
                 r = session.post(config.BLOCK_OBSERVATORY_URL, json=block)
                 r.raise_for_status()
                 print('Uploaded block ' + str(x) + '.')
     else:
         print('Error: Can\'t retrieve blocks from zcashd.')
-        exit(1)
-    exit(0)
+        sys.exit(1)
+    sys.exit(0)
 
 if __name__ == '__main__':
     main()

--- a/receiveblocks.py
+++ b/receiveblocks.py
@@ -13,13 +13,13 @@ def createdb():
     c = conn.cursor()
 
     c.execute('CREATE TABLE IF NOT EXISTS tx( \
-        hash TEXT(100) NOT NULL, \
-        tx TEXT(100) NOT NULL, \
+        hash TEXT NOT NULL, \
+        tx TEXT NOT NULL, \
         FOREIGN KEY (hash) REFERENCES blocks(hash) \
         PRIMARY KEY(tx))')
 
     c.execute('CREATE TABLE IF NOT EXISTS blocks( \
-        hash TEXT(100) NOT NULL, \
+        hash TEXT NOT NULL, \
         confirmations INTEGER, \
         size INTEGER NOT NULL, \
         height INTEGER NOT NULL, \
@@ -28,13 +28,13 @@ def createdb():
         tx BLOB, \
         txs INTEGER, \
         time REAL NOT NULL, \
-        nonce TEXT(100) NOT NULL, \
-        bits TEXT(50) NOT NULL, \
-        difficulty TEXT(50) NOT NULL, \
-        chainwork TEXT(100) NOT NULL, \
-        anchor TEXT(100) NOT NULL, \
-        previousblockhash TEXT(100), \
-        nextblockhash TEXT(100), \
+        nonce TEXT NOT NULL, \
+        bits TEXT NOT NULL, \
+        difficulty TEXT NOT NULL, \
+        chainwork TEXT NOT NULL, \
+        anchor TEXT NOT NULL, \
+        previousblockhash TEXT, \
+        nextblockhash TEXT, \
         arrivaltime REAL, \
         PRIMARY KEY (hash))')
     conn.execute('VACUUM')

--- a/receiveblocks.py
+++ b/receiveblocks.py
@@ -12,6 +12,7 @@ app.config.from_object(config.FlaskConfig)
 def createdb():
     conn = sqlite3.connect(db_file)
     c = conn.cursor()
+
     c.execute('CREATE TABLE IF NOT EXISTS tx( \
         hash TEXT(100) NOT NULL, \
         tx TEXT(100) NOT NULL, \
@@ -25,6 +26,7 @@ def createdb():
         height REAL NOT NULL, \
         version REAL NOT NULL, \
         merkleroot TEXT(100) NOT NULL, \
+        tx BLOB, \
         time REAL NOT NULL, \
         nonce TEXT(100) NOT NULL, \
         bits TEXT(50) NOT NULL, \
@@ -43,10 +45,10 @@ def storeblock(block):
     conn = sqlite3.connect(db_file)
     c = conn.cursor()
     try:
-        c.execute('INSERT INTO blocks (hash, confirmations, size, height, version, merkleroot, \
+        c.execute('INSERT INTO blocks (hash, confirmations, size, height, version, merkleroot, tx, \
             time, nonce, bits, difficulty, chainwork, anchor, previousblockhash, nextblockhash, arrivaltime) \
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', (block['hash'], block['confirmations'], \
-            block['size'], block['height'], block['version'], block['merkleroot'], block['time'], \
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', (block['hash'], block['confirmations'], \
+            block['size'], block['height'], block['version'], block['merkleroot'], json.dumps(block['tx']), block['time'], \
             block['nonce'], block['bits'], block['difficulty'], block['chainwork'], block['anchor'], \
             block.get('previousblockhash', None), block.get('nextblockhash', None), block.get('arrivaltime', None)))
         try:

--- a/receiveblocks.py
+++ b/receiveblocks.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from functools import wraps
-from flask import Flask, abort, jsonify, request, Response, session
-import config, json, os, sqlite3, sys
+from flask import Flask, request
+import config, json, sqlite3
 
 db_file = 'blocks.sqlite'
 app = Flask(__name__)
@@ -62,13 +61,13 @@ def storeblock(block):
             try:
                 c.execute('UPDATE blocks SET nextblockhash=:nextblockhash WHERE hash=:hash',
                     {"nextblockhash": block['nextblockhash'], "hash": block['hash']})
-                print 'Updated nextblockhash on block ' + block['height']
+                print('Updated nextblockhash on block ' + block['height'])
             except:
                 pass
         try:
             c.execute('UPDATE blocks SET confirmations=:confirmations WHERE hash=:hash',
                 {"confirmations": block['confirmations'], "hash": block['hash']})
-            print 'Updated confirmations on block ' + block['height']
+            print('Updated confirmations on block ' + block['height'])
         except:
             pass
     for tx in block['tx']:
@@ -81,7 +80,7 @@ def storeblock(block):
 
 @app.route('/', methods = ['POST'])
 def index():
-    print request.get_data()
+    print(request.get_data())
     if request.method == 'POST' and request.content_type == 'application/json':
         storeblock(request.get_json())
         return ('', 204)

--- a/receiveblocks.py
+++ b/receiveblocks.py
@@ -21,12 +21,13 @@ def createdb():
 
     c.execute('CREATE TABLE IF NOT EXISTS blocks( \
         hash TEXT(100) NOT NULL, \
-        confirmations REAL NOT NULL, \
-        size REAL NOT NULL, \
-        height REAL NOT NULL, \
-        version REAL NOT NULL, \
+        confirmations INTEGER, \
+        size INTEGER NOT NULL, \
+        height INTEGER NOT NULL, \
+        version REAL, \
         merkleroot TEXT(100) NOT NULL, \
         tx BLOB, \
+        txs INTEGER, \
         time REAL NOT NULL, \
         nonce TEXT(100) NOT NULL, \
         bits TEXT(50) NOT NULL, \
@@ -45,10 +46,10 @@ def storeblock(block):
     conn = sqlite3.connect(db_file)
     c = conn.cursor()
     try:
-        c.execute('INSERT INTO blocks (hash, confirmations, size, height, version, merkleroot, tx, \
+        c.execute('INSERT INTO blocks (hash, confirmations, size, height, version, merkleroot, tx, txs, \
             time, nonce, bits, difficulty, chainwork, anchor, previousblockhash, nextblockhash, arrivaltime) \
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', (block['hash'], block['confirmations'], \
-            block['size'], block['height'], block['version'], block['merkleroot'], json.dumps(block['tx']), block['time'], \
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', (block['hash'], block['confirmations'], \
+            block['size'], block['height'], block['version'], block['merkleroot'], json.dumps(block['tx']), len(block['tx']), block['time'], \
             block['nonce'], block['bits'], block['difficulty'], block['chainwork'], block['anchor'], \
             block.get('previousblockhash', None), block.get('nextblockhash', None), block.get('arrivaltime', None)))
         try:

--- a/sendblock.py
+++ b/sendblock.py
@@ -1,11 +1,19 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+"""
+Sends incoming blocks from a locally-running zcashd to a remote collector.
+"""
+import json
+import time
+import subprocess
+import sys
+import requests
 
-import json, os, requests, subprocess, sys, time
-block_observatory_url = 'http://127.0.0.1:8200/'
+from config import SendBlocksConfig
+config = SendBlocksConfig
 
 def zcash(block_hash):
-    zcash = subprocess.Popen(['/usr/bin/zcash-cli', 'getblock', block_hash], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    zcash = subprocess.Popen([config.ZCASH_CLI_PATH, 'getblock', block_hash], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
     output = zcash.communicate()[0]
     return json.loads(output)
 
@@ -16,7 +24,7 @@ def main():
     block['arrivaltime'] = timestamp
     session = requests.session()
     session.headers.update({'Content-Type': 'application/json'})
-    r = session.post(block_observatory_url, json=block)
+    r = session.post(config['BLOCK_OBSERVATORY_URL'], json=block)
     r.raise_for_status()
 
 if __name__ == '__main__':

--- a/sendblock.py
+++ b/sendblock.py
@@ -13,8 +13,8 @@ from config import SendBlocksConfig
 config = SendBlocksConfig
 
 def zcash(block_hash):
-    zcash = subprocess.Popen([config.ZCASH_CLI_PATH, 'getblock', block_hash], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-    output = zcash.communicate()[0]
+    zcexec = subprocess.Popen([config.ZCASH_CLI_PATH, 'getblock', block_hash], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    output = zcexec.communicate()[0]
     return json.loads(output)
 
 def main():
@@ -26,6 +26,7 @@ def main():
     session.headers.update({'Content-Type': 'application/json'})
     r = session.post(config['BLOCK_OBSERVATORY_URL'], json=block)
     r.raise_for_status()
+    sys.exit(0)
 
 if __name__ == '__main__':
     main()

--- a/showblocks.py
+++ b/showblocks.py
@@ -99,6 +99,7 @@ def show_block():
         block = get_single_block(search_string)
         return render_template('block.html', block = block)
     except:
+        print 'failed to find block by hash'
         pass
     # find block by transaction ID
     try:
@@ -106,6 +107,7 @@ def show_block():
         block = get_single_block(block_hash)
         return render_template('block.html', block = block)
     except:
+        print 'failed to find block by txid'
         pass
     # find block by height
     try:
@@ -113,7 +115,7 @@ def show_block():
         block = get_single_block(block_hash)
         return render_template('block.html', block = block)
     except:
-        print 'except'
+        print 'failed to find block by number'
         return ('', 204)
 
 if __name__ == '__main__':

--- a/showblocks.py
+++ b/showblocks.py
@@ -1,13 +1,9 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
-from functools import wraps
-from flask import Flask, g, abort, jsonify, render_template, request, Response, session
+from flask import Flask, render_template, request, session
 import config, json, os, re, sqlite3, sys, time
 from werkzeug.contrib.cache import SimpleCache
-
-# debugging
-from pprint import pprint
 
 db_file = 'blocks.sqlite'
 app = Flask(__name__)

--- a/showblocks.py
+++ b/showblocks.py
@@ -58,11 +58,14 @@ def get_blocks():
 def validate_input(search_string):
     if search_string.isdigit():
         if int(search_string) <= latest_block():
+            print('Search is numeric but not less than the current block height.')
             return search_string
     if len(search_string) != 64:
+        print('Error: Search does not consist of 64 characters.')
         return None
     m = re.match(r"[A-Fa-f0-9]{64}", search_string)
     if m and m.span()[1] == len(search_string):
+        print('Search matches the hexademical format of a block hash or txid.')
         return search_string
     else:
         return None
@@ -108,7 +111,7 @@ def show_block():
         block = get_single_block(block_hash)
         return render_template('block.html', block = block)
     except:
-        print('Error: Failed to locate block by its number.')
+        print('Error: Failed to locate block by height.')
         return ('', 204)
 
 if __name__ == '__main__':

--- a/showblocks.py
+++ b/showblocks.py
@@ -65,7 +65,7 @@ def validate_input(search_string):
         return None
     m = re.match(r"[A-Fa-f0-9]{64}", search_string)
     if m and m.span()[1] == len(search_string):
-        print('Search matches the hexademical format of a block hash or txid.')
+        print('Search matches hexademical format of a block hash or txid.')
         return search_string
     else:
         return None

--- a/showblocks.py
+++ b/showblocks.py
@@ -82,17 +82,17 @@ def index():
 
 @app.route('/block', methods = ['GET', 'POST'])
 def show_block():
-    print 'search: ', request.values.get('search')
+    print('Searching: ' + request.values.get('search'))
     search_string = validate_input(request.values.get('search').strip().lower())
     if search_string is None:
-        print 'blockhash search none'
+        print('Error: Search string was invalid.')
         return ('', 204)
     # find block by hash
     try:
         block = get_single_block(search_string)
         return render_template('block.html', block = block)
     except:
-        print 'failed to find block by hash'
+        print('Error: Failed to locate block by hash.')
         pass
     # find block by transaction ID
     try:
@@ -100,7 +100,7 @@ def show_block():
         block = get_single_block(block_hash)
         return render_template('block.html', block = block)
     except:
-        print 'failed to find block by txid'
+        print('Error: Failed to locate block by txid.')
         pass
     # find block by height
     try:
@@ -108,7 +108,7 @@ def show_block():
         block = get_single_block(block_hash)
         return render_template('block.html', block = block)
     except:
-        print 'failed to find block by number'
+        print('Error: Failed to locate block by its number.')
         return ('', 204)
 
 if __name__ == '__main__':

--- a/showblocks.py
+++ b/showblocks.py
@@ -46,17 +46,10 @@ def get_single_block(block_hash):
     block = dict(c.fetchone())
     return block
 
-def get_blocks(query={}):
-    if query.get('height'):
-        height = query['height']
+def get_blocks():
     conn = sqlite3.connect(db_file)
     conn.row_factory = sqlite3.Row
     c = conn.cursor()
-    # if height == 'top':
-    #     c.execute('SELECT hash, height, size, time FROM blocks ORDER by height DESC LIMIT 20')
-    # else:
-    #     bottom = height - 20
-    #     c.execute('SELECT hash, height, size, time FROM blocks WHERE height<=:top AND height>:bottom ORDER by height DESC', {"top":height, "bottom":bottom})
     c.execute('SELECT hash, height, size, txs, time FROM blocks ORDER by height DESC LIMIT 200')
     # return retrieved blocks as a dict
     blocks = [dict(block) for block in c.fetchall()]
@@ -78,13 +71,10 @@ def validate_input(search_string):
 def _jinja2_filter_timestamp(unix_epoch):
     return time.ctime(unix_epoch)
 
-# @app.route('/', defaults={'height': 'top'})
-# @app.route('/height/<int:height>')
 @app.route('/')
-def index(height='top'):
-    query = {"height":height}
+def index():
     try:
-        blocks = get_blocks(query)
+        blocks = get_blocks()
         # blocks = cache.get('blocks')
     except:
         pass

--- a/showblocks.py
+++ b/showblocks.py
@@ -25,8 +25,8 @@ def find_block_by_tx(txid):
     conn = sqlite3.connect(db_file)
     conn.row_factory = sqlite3.Row
     c = conn.cursor()
-    #c.execute('SELECT hash FROM tx WHERE tx=:txid', {"txid": txid})
-    c.execute('SELECT hash FROM blocks WHERE instr(tx, :txid)', {"txid": txid})
+    c.execute('SELECT hash FROM tx WHERE tx=:txid', {"txid": txid})
+    #c.execute('SELECT hash FROM blocks WHERE instr(tx, :txid)', {"txid": txid})
     block_hash = c.fetchone()
     return str(block_hash['hash'])
 
@@ -43,8 +43,8 @@ def get_single_block(block_hash):
     conn.row_factory = sqlite3.Row
     c = conn.cursor()
     c.execute('SELECT * FROM blocks WHERE hash=:hash', {"hash": block_hash})
-    block = dict(c.fetchone())
-    return block
+    block = c.fetchone()
+    return dict(block)
 
 def get_blocks():
     conn = sqlite3.connect(db_file)

--- a/showblocks.py
+++ b/showblocks.py
@@ -6,6 +6,9 @@ from flask import Flask, g, abort, jsonify, render_template, request, Response, 
 import config, json, os, re, sqlite3, sys, time
 from werkzeug.contrib.cache import SimpleCache
 
+# debugging
+from pprint import pprint
+
 db_file = 'blocks.sqlite'
 app = Flask(__name__)
 app.config.from_object(config.FlaskConfig)
@@ -54,7 +57,7 @@ def get_blocks(query={}):
     # else:
     #     bottom = height - 20
     #     c.execute('SELECT hash, height, size, time FROM blocks WHERE height<=:top AND height>:bottom ORDER by height DESC', {"top":height, "bottom":bottom})
-    c.execute('SELECT hash, height, size, LENGTH(tx) AS txs, time FROM blocks ORDER by height DESC LIMIT 200')
+    c.execute('SELECT hash, height, size, txs, time FROM blocks ORDER by height DESC LIMIT 200')
     # return retrieved blocks as a dict
     blocks = [dict(block) for block in c.fetchall()]
     return blocks

--- a/templates/block.html
+++ b/templates/block.html
@@ -28,7 +28,7 @@
       <tr>
         <th>txs</th>
         <td>
-        {% for tx in block['tx'] %}
+        {% for tx in transactions %}
         {{ tx }}<br>
         {% endfor %}
         </td>
@@ -63,7 +63,7 @@
       </tr>
       <tr>
         <th>nextblockhash</th>
-        {% if str(nextblockhash) == 'None' %}
+        {% if block['nextblockhash'] | string() == 'None' %}
         <td>None</td>
         {% else %}
         <td><a href="/block?search={{ block['nextblockhash'] }}" style="text-decoration: none;">{{ block['nextblockhash'] }}</a></td>

--- a/templates/block.html
+++ b/templates/block.html
@@ -29,7 +29,7 @@
         <th>txs</th>
         <td>
         {% for tx in transactions %}
-        {{ tx }}<br>
+          {{ tx }}<br>
         {% endfor %}
         </td>
       </tr>
@@ -63,7 +63,7 @@
       </tr>
       <tr>
         <th>nextblockhash</th>
-        {% if block['nextblockhash'] | string() == 'None' %}
+        {% if block['nextblockhash'] | string == 'None' %}
         <td>None</td>
         {% else %}
         <td><a href="/block?search={{ block['nextblockhash'] }}" style="text-decoration: none;">{{ block['nextblockhash'] }}</a></td>

--- a/templates/block.html
+++ b/templates/block.html
@@ -29,7 +29,7 @@
         <th>txs</th>
         <td>
         {% for tx in block['tx'] %}
-        {{ tx['tx'] }}<br>
+        {{ tx }}<br>
         {% endfor %}
         </td>
       </tr>

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -17,8 +17,7 @@
           <td>{{ block['height'] | int }}</td>
           <td><a href="/block?search={{ block['hash'] }}" style="text-decoration: none;">{{ block['hash'] }}</a></td>
           <td>{{ block['size'] | int }}</td>
-          <td>
-            {{ block['txs']|length }}
+          <td>{{ block['txs'] | int }}
           </td>
           <td>{{ block['time'] | timestamp }}</td>
         </tr>

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -17,8 +17,7 @@
           <td>{{ block['height'] | int }}</td>
           <td><a href="/block?search={{ block['hash'] }}" style="text-decoration: none;">{{ block['hash'] }}</a></td>
           <td>{{ block['size'] | int }}</td>
-          <td>{{ block['txs'] | int }}
-          </td>
+          <td>{{ block['txs'] | int }}</td>
           <td>{{ block['time'] | timestamp }}</td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
This is a million times faster! I moved both the transactions themselves (as a BLOB object) plus the `txs` = `len(json.loads(block['tx']))` as columns in the `blocks` table. I'm keeping the tx table around for now in case we'll still need it.