### PR TITLE
Use cache and allow variable query for blocks

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 class FlaskConfig(object):
-  DEBUG = False
-  TESTING = False
+  DEBUG = True
+  TESTING = True
+  TEMPLATE_DEBUG = True
   WTF_CSRF_ENABLED = False
   SECRET_KEY = 'lQT0EE/XcyZrXDjCCJ/KRs3F2zKc0Ls3KAmT4y0pxp4='

--- a/receiveblocks.py
+++ b/receiveblocks.py
@@ -12,6 +12,7 @@ app.config.from_object(config.FlaskConfig)
 def createdb():
     conn = sqlite3.connect(db_file)
     c = conn.cursor()
+
     c.execute('CREATE TABLE IF NOT EXISTS tx( \
         hash TEXT(100) NOT NULL, \
         tx TEXT(100) NOT NULL, \
@@ -25,6 +26,7 @@ def createdb():
         height REAL NOT NULL, \
         version REAL NOT NULL, \
         merkleroot TEXT(100) NOT NULL, \
+        tx BLOB, \
         time REAL NOT NULL, \
         nonce TEXT(100) NOT NULL, \
         bits TEXT(50) NOT NULL, \
@@ -43,10 +45,10 @@ def storeblock(block):
     conn = sqlite3.connect(db_file)
     c = conn.cursor()
     try:
-        c.execute('INSERT INTO blocks (hash, confirmations, size, height, version, merkleroot, \
+        c.execute('INSERT INTO blocks (hash, confirmations, size, height, version, merkleroot, tx, \
             time, nonce, bits, difficulty, chainwork, anchor, previousblockhash, nextblockhash, arrivaltime) \
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', (block['hash'], block['confirmations'], \
-            block['size'], block['height'], block['version'], block['merkleroot'], block['time'], \
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', (block['hash'], block['confirmations'], \
+            block['size'], block['height'], block['version'], block['merkleroot'], json.dumps(block['tx']), block['time'], \
             block['nonce'], block['bits'], block['difficulty'], block['chainwork'], block['anchor'], \
             block.get('previousblockhash', None), block.get('nextblockhash', None), block.get('arrivaltime', None)))
         try:

--- a/receiveblocks.py
+++ b/receiveblocks.py
@@ -21,12 +21,13 @@ def createdb():
 
     c.execute('CREATE TABLE IF NOT EXISTS blocks( \
         hash TEXT(100) NOT NULL, \
-        confirmations REAL NOT NULL, \
-        size REAL NOT NULL, \
-        height REAL NOT NULL, \
-        version REAL NOT NULL, \
+        confirmations INTEGER, \
+        size INTEGER NOT NULL, \
+        height INTEGER NOT NULL, \
+        version REAL, \
         merkleroot TEXT(100) NOT NULL, \
         tx BLOB, \
+        txs INTEGER, \
         time REAL NOT NULL, \
         nonce TEXT(100) NOT NULL, \
         bits TEXT(50) NOT NULL, \
@@ -45,10 +46,10 @@ def storeblock(block):
     conn = sqlite3.connect(db_file)
     c = conn.cursor()
     try:
-        c.execute('INSERT INTO blocks (hash, confirmations, size, height, version, merkleroot, tx, \
+        c.execute('INSERT INTO blocks (hash, confirmations, size, height, version, merkleroot, tx, txs, \
             time, nonce, bits, difficulty, chainwork, anchor, previousblockhash, nextblockhash, arrivaltime) \
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', (block['hash'], block['confirmations'], \
-            block['size'], block['height'], block['version'], block['merkleroot'], json.dumps(block['tx']), block['time'], \
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', (block['hash'], block['confirmations'], \
+            block['size'], block['height'], block['version'], block['merkleroot'], json.dumps(block['tx']), len(block['tx']), block['time'], \
             block['nonce'], block['bits'], block['difficulty'], block['chainwork'], block['anchor'], \
             block.get('previousblockhash', None), block.get('nextblockhash', None), block.get('arrivaltime', None)))
         try:

--- a/showblocks.py
+++ b/showblocks.py
@@ -99,6 +99,7 @@ def show_block():
         block = get_single_block(search_string)
         return render_template('block.html', block = block)
     except:
+        print 'failed to find block by hash'
         pass
     # find block by transaction ID
     try:
@@ -106,6 +107,7 @@ def show_block():
         block = get_single_block(block_hash)
         return render_template('block.html', block = block)
     except:
+        print 'failed to find block by txid'
         pass
     # find block by height
     try:
@@ -113,7 +115,7 @@ def show_block():
         block = get_single_block(block_hash)
         return render_template('block.html', block = block)
     except:
-        print 'except'
+        print 'failed to find block by number'
         return ('', 204)
 
 if __name__ == '__main__':

--- a/showblocks.py
+++ b/showblocks.py
@@ -1,13 +1,9 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
-from functools import wraps
-from flask import Flask, g, abort, jsonify, render_template, request, Response, session
+from flask import Flask, render_template, request, session
 import config, json, os, re, sqlite3, sys, time
 from werkzeug.contrib.cache import SimpleCache
-
-# debugging
-from pprint import pprint
 
 db_file = 'blocks.sqlite'
 app = Flask(__name__)

--- a/showblocks.py
+++ b/showblocks.py
@@ -58,11 +58,14 @@ def get_blocks():
 def validate_input(search_string):
     if search_string.isdigit():
         if int(search_string) <= latest_block():
+            print('Search is numeric but not less than the current block height.')
             return search_string
     if len(search_string) != 64:
+        print('Error: Search does not consist of 64 characters.')
         return None
     m = re.match(r"[A-Fa-f0-9]{64}", search_string)
     if m and m.span()[1] == len(search_string):
+        print('Search matches the hexademical format of a block hash or txid.')
         return search_string
     else:
         return None
@@ -108,7 +111,7 @@ def show_block():
         block = get_single_block(block_hash)
         return render_template('block.html', block = block)
     except:
-        print('Error: Failed to locate block by its number.')
+        print('Error: Failed to locate block by height.')
         return ('', 204)
 
 if __name__ == '__main__':

--- a/showblocks.py
+++ b/showblocks.py
@@ -65,7 +65,7 @@ def validate_input(search_string):
         return None
     m = re.match(r"[A-Fa-f0-9]{64}", search_string)
     if m and m.span()[1] == len(search_string):
-        print('Search matches the hexademical format of a block hash or txid.')
+        print('Search matches hexademical format of a block hash or txid.')
         return search_string
     else:
         return None

--- a/showblocks.py
+++ b/showblocks.py
@@ -42,11 +42,11 @@ def get_single_block(block_hash):
     block = c.fetchone()
     return dict(block)
 
-def get_blocks():
+def get_blocks(amount=-1):
     conn = sqlite3.connect(db_file)
     conn.row_factory = sqlite3.Row
     c = conn.cursor()
-    c.execute('SELECT hash, height, size, txs, time FROM blocks ORDER by height DESC LIMIT 200')
+    c.execute('SELECT hash, height, size, txs, time FROM blocks ORDER by height DESC LIMIT ' + (str(amount) if (int(amount) > 0) else str('-1')))
     # return retrieved blocks as a dict
     blocks = [dict(block) for block in c.fetchall()]
     return blocks
@@ -73,8 +73,8 @@ def _jinja2_filter_timestamp(unix_epoch):
 @app.route('/')
 def index():
     try:
-        blocks = get_blocks()
-        # blocks = cache.get('blocks')
+        #blocks = get_blocks(250)
+        blocks = cache.get('blocks')
     except:
         pass
     return render_template('blocks.html', blocks = blocks)
@@ -111,6 +111,6 @@ def show_block():
         return ('', 204)
 
 if __name__ == '__main__':
-    # cache = SimpleCache()
-    # cache.set('blocks', get_blocks(), timeout=3600)
+    cache = SimpleCache()
+    cache.set('blocks', get_blocks(250), timeout=3600)
     app.run(host='0.0.0.0', port=int('8201'), debug=True)

--- a/showblocks.py
+++ b/showblocks.py
@@ -82,17 +82,17 @@ def index():
 
 @app.route('/block', methods = ['GET', 'POST'])
 def show_block():
-    print 'search: ', request.values.get('search')
+    print('Searching: ' + request.values.get('search'))
     search_string = validate_input(request.values.get('search').strip().lower())
     if search_string is None:
-        print 'blockhash search none'
+        print('Error: Search string was invalid.')
         return ('', 204)
     # find block by hash
     try:
         block = get_single_block(search_string)
         return render_template('block.html', block = block)
     except:
-        print 'failed to find block by hash'
+        print('Error: Failed to locate block by hash.')
         pass
     # find block by transaction ID
     try:
@@ -100,7 +100,7 @@ def show_block():
         block = get_single_block(block_hash)
         return render_template('block.html', block = block)
     except:
-        print 'failed to find block by txid'
+        print('Error: Failed to locate block by txid.')
         pass
     # find block by height
     try:
@@ -108,7 +108,7 @@ def show_block():
         block = get_single_block(block_hash)
         return render_template('block.html', block = block)
     except:
-        print 'failed to find block by number'
+        print('Error: Failed to locate block by its number.')
         return ('', 204)
 
 if __name__ == '__main__':

--- a/showblocks.py
+++ b/showblocks.py
@@ -46,17 +46,10 @@ def get_single_block(block_hash):
     block = dict(c.fetchone())
     return block
 
-def get_blocks(query={}):
-    if query.get('height'):
-        height = query['height']
+def get_blocks():
     conn = sqlite3.connect(db_file)
     conn.row_factory = sqlite3.Row
     c = conn.cursor()
-    # if height == 'top':
-    #     c.execute('SELECT hash, height, size, time FROM blocks ORDER by height DESC LIMIT 20')
-    # else:
-    #     bottom = height - 20
-    #     c.execute('SELECT hash, height, size, time FROM blocks WHERE height<=:top AND height>:bottom ORDER by height DESC', {"top":height, "bottom":bottom})
     c.execute('SELECT hash, height, size, txs, time FROM blocks ORDER by height DESC LIMIT 200')
     # return retrieved blocks as a dict
     blocks = [dict(block) for block in c.fetchall()]
@@ -78,13 +71,10 @@ def validate_input(search_string):
 def _jinja2_filter_timestamp(unix_epoch):
     return time.ctime(unix_epoch)
 
-# @app.route('/', defaults={'height': 'top'})
-# @app.route('/height/<int:height>')
 @app.route('/')
-def index(height='top'):
-    query = {"height":height}
+def index():
     try:
-        blocks = get_blocks(query)
+        blocks = get_blocks()
         # blocks = cache.get('blocks')
     except:
         pass

--- a/showblocks.py
+++ b/showblocks.py
@@ -25,8 +25,8 @@ def find_block_by_tx(txid):
     conn = sqlite3.connect(db_file)
     conn.row_factory = sqlite3.Row
     c = conn.cursor()
-    #c.execute('SELECT hash FROM tx WHERE tx=:txid', {"txid": txid})
-    c.execute('SELECT hash FROM blocks WHERE instr(tx, :txid)', {"txid": txid})
+    c.execute('SELECT hash FROM tx WHERE tx=:txid', {"txid": txid})
+    #c.execute('SELECT hash FROM blocks WHERE instr(tx, :txid)', {"txid": txid})
     block_hash = c.fetchone()
     return str(block_hash['hash'])
 
@@ -43,8 +43,8 @@ def get_single_block(block_hash):
     conn.row_factory = sqlite3.Row
     c = conn.cursor()
     c.execute('SELECT * FROM blocks WHERE hash=:hash', {"hash": block_hash})
-    block = dict(c.fetchone())
-    return block
+    block = c.fetchone()
+    return dict(block)
 
 def get_blocks():
     conn = sqlite3.connect(db_file)

--- a/showblocks.py
+++ b/showblocks.py
@@ -6,6 +6,9 @@ from flask import Flask, g, abort, jsonify, render_template, request, Response, 
 import config, json, os, re, sqlite3, sys, time
 from werkzeug.contrib.cache import SimpleCache
 
+# debugging
+from pprint import pprint
+
 db_file = 'blocks.sqlite'
 app = Flask(__name__)
 app.config.from_object(config.FlaskConfig)
@@ -54,7 +57,7 @@ def get_blocks(query={}):
     # else:
     #     bottom = height - 20
     #     c.execute('SELECT hash, height, size, time FROM blocks WHERE height<=:top AND height>:bottom ORDER by height DESC', {"top":height, "bottom":bottom})
-    c.execute('SELECT hash, height, size, LENGTH(tx) AS txs, time FROM blocks ORDER by height DESC LIMIT 200')
+    c.execute('SELECT hash, height, size, txs, time FROM blocks ORDER by height DESC LIMIT 200')
     # return retrieved blocks as a dict
     blocks = [dict(block) for block in c.fetchall()]
     return blocks

--- a/templates/block.html
+++ b/templates/block.html
@@ -29,7 +29,7 @@
         <th>txs</th>
         <td>
         {% for tx in block['tx'] %}
-        {{ tx['tx'] }}<br>
+        {{ tx }}<br>
         {% endfor %}
         </td>
       </tr>

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -17,8 +17,7 @@
           <td>{{ block['height'] | int }}</td>
           <td><a href="/block?search={{ block['hash'] }}" style="text-decoration: none;">{{ block['hash'] }}</a></td>
           <td>{{ block['size'] | int }}</td>
-          <td>
-            {{ block['txs']|length }}
+          <td>{{ block['txs'] | int }}
           </td>
           <td>{{ block['time'] | timestamp }}</td>
         </tr>


### PR DESCRIPTION
This will have to be merged after https://github.com/ageis/zcash-block-observatory/pull/3 and goes back to using the SimpleCache to store blocks displayed on the main page.

Commit: https://github.com/ageis/zcash-block-observatory/commit/1f500cec564f3402d4e64c2f9ed5518dea425719

For now it's just something I developed since I learned about in-line conditionals and that you can pass `LIMIT -1` to SQL, but this all may have to be rewritten once we do pagination right.

In Python 3.5, you can explicitly specify the type of an argument passed to a function, as well as what it's supposed to return, which I think is pretty cool.
```
def greeting(name: str) -> str:
    return 'Hello ' + name
```